### PR TITLE
Toolbar changes and new view editor changes

### DIFF
--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-canvas/view-canvas.component.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-canvas/view-canvas.component.ts
@@ -75,7 +75,7 @@ export class ViewCanvasComponent implements OnInit, OnDestroy {
    */
   public get hasViewSources(): boolean {
     const view = this.editorService.getEditorView();
-    if (view !== null) {
+    if (view) {
       return view.getSources().length > 0;
     }
     return false;

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor-header/view-editor-header.component.html
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor-header/view-editor-header.component.html
@@ -7,9 +7,11 @@
     <label class="col-sm-2 control-label view-editor-header-label"
            for="view-editor-header-virtualization-name">Virtualization:
     </label>
-    <label class="col-sm-7 control-label view-editor-header-label"
-           id="view-editor-header-virtualization-name">{{virtualizationName}}
-    </label>
+    <a class="col-sm-7 control-label view-editor-header-label"
+       id="view-editor-header-virtualization-name"
+       [routerLink]="[virtualizationLink]"
+       (click)="onClick(editEvent)">{{virtualizationName}}
+    </a>
   </div>
 
   <!-- ========= -->

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor-header/view-editor-header.component.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor-header/view-editor-header.component.ts
@@ -21,6 +21,7 @@ import { ViewEditorPart } from "@dataservices/virtualization/view-editor/view-ed
 import { ViewEditorService } from "@dataservices/virtualization/view-editor/view-editor.service";
 import { ViewEditorEvent } from "@dataservices/virtualization/view-editor/event/view-editor-event";
 import { Subscription } from "rxjs/Subscription";
+import { DataservicesConstants } from "@dataservices/shared/dataservices-constants";
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -118,6 +119,13 @@ export class ViewEditorHeaderComponent implements OnInit, OnDestroy {
    */
   public viewNameChanged( newName: string ): void {
     this.viewName = newName;
+  }
+
+  /**
+   * @returns {string} the router link of the virtualization
+   */
+  public get virtualizationLink(): string {
+    return this.editorService.getVirtualizationLink();
   }
 
   /**

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor.component.css
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor.component.css
@@ -106,10 +106,15 @@
   margin: 2px;
 }
 
+.view-editor-toolbar-end-group {
+  margin-right: 1em;
+}
+
 /*
  * Make the toolbar buttons smaller.
  */
 .view-editor-toolbar-icon {
+  color: var(--card-action-icon-color);
   font-size: xx-small;
 }
 

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor.component.html
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor.component.html
@@ -51,16 +51,16 @@
               <span class="fa fa-plus view-editor-toolbar-icon"></span>
             </ng-template>
             <ng-template #undoTemplate let-action="action">
-              <span class="fa fa-rotate-left view-editor-toolbar-icon"></span>
+              <span class="fa fa-rotate-left view-editor-toolbar-icon" style="color: gold;"></span>
             </ng-template>
             <ng-template #redoTemplate let-action="action">
-              <span class="fa fa-rotate-right view-editor-toolbar-icon"></span>
+              <span class="fa fa-rotate-right view-editor-toolbar-icon" style="color: gold;"></span>
             </ng-template>
             <ng-template #saveTemplate let-action="action">
-              <span class="pficon pficon-save view-editor-toolbar-icon"></span>
+              <span class="fa fa-save view-editor-toolbar-icon"></span>
             </ng-template>
             <ng-template #deleteTemplate let-action="action">
-              <span class="pficon pficon-delete view-editor-toolbar-icon"></span>
+              <span class="pficon pficon-delete view-editor-toolbar-icon" style="color: var(--alert-color)"></span>
             </ng-template>
             <ng-template #errorsTemplate let-action="action">
               <span class="pficon pficon-error-circle-o badge-pf-bordered view-editor-toolbar-icon">{{errorMsgCount}}</span>

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor.service.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor.service.ts
@@ -26,6 +26,7 @@ import { ViewEditorPart } from "@dataservices/virtualization/view-editor/view-ed
 import { Message } from "@dataservices/virtualization/view-editor/editor-views/message-log/message";
 import { Problem } from "@dataservices/virtualization/view-editor/editor-views/message-log/problem";
 import { SchemaNode } from "@connections/shared/schema-node.model";
+import { DataservicesConstants } from "@dataservices/shared/dataservices-constants";
 
 @Injectable()
 export class ViewEditorService {
@@ -174,10 +175,19 @@ export class ViewEditorService {
    */
   public getViewName(): string {
     if ( this._editorView ) {
-      return this._editorView.getName();
+      if ( this._editorView.getName() ) {
+        return this._editorView.getName();
+      }
     }
 
     return "";
+  }
+
+  /**
+   * @returns {string} the router link of the virtualization
+   */
+  public getVirtualizationLink(): string {
+    return DataservicesConstants.virtualizationPath;
   }
 
   /**


### PR DESCRIPTION
- added space between toolbar button groups
- name of virtualization in editor header is now a link back to the virualization page
- toolbar icon colors are the same as the card icons now
- moved save toolbar button left of undo and redo