### PR TITLE
Fixed the bug in message log where the incorrect message was being shown

### DIFF
--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/editor-views/message-log/message-log.component.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/editor-views/message-log/message-log.component.ts
@@ -15,11 +15,9 @@
  * limitations under the License.
  */
 
-import { Component, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
+import { Component, OnInit, ViewEncapsulation } from '@angular/core';
 import { LoggerService } from "@core/logger.service";
 import { ViewEditorService } from "@dataservices/virtualization/view-editor/view-editor.service";
-import { Subscription } from "rxjs/Subscription";
-import { ViewEditorEvent } from "@dataservices/virtualization/view-editor/event/view-editor-event";
 import { EmptyStateConfig, NgxDataTableConfig, TableConfig } from "patternfly-ng";
 import { Message } from "@dataservices/virtualization/view-editor/editor-views/message-log/message";
 
@@ -29,80 +27,47 @@ import { Message } from "@dataservices/virtualization/view-editor/editor-views/m
   templateUrl: './message-log.component.html',
   styleUrls: ['./message-log.component.css']
 })
-export class MessageLogComponent implements OnInit, OnDestroy {
+export class MessageLogComponent implements OnInit {
 
   public columns: any[];
   private emptyStateConfig: EmptyStateConfig;
   public ngxConfig: NgxDataTableConfig;
   public tableConfig: TableConfig;
-  // public rows: any[] = [];
 
   private readonly editorService: ViewEditorService;
   private readonly logger: LoggerService;
-  private subscription: Subscription;
 
   constructor( logger: LoggerService,
                editorService: ViewEditorService ) {
     this.logger = logger;
     this.editorService = editorService;
   }
-  //
-  // private clearMessages(): void {
-  //   if ( this.rows && this.rows.length !== 0 ) {
-  //     this.rows = [];
-  //   }
-  // }
-
-  /**
-   * @param {ViewEditorEvent} event the event being processed
-   */
-  public handleEditorEvent( event: ViewEditorEvent ): void {
-    this.logger.debug( "MessageLogComponent received event: " + event.toString() );
-    //
-    // if ( event.typeIsLogMessageAdded() ) {
-    //   this.rows.push( event.args[ 0 ] );
-    // } else if ( event.typeIsLogMessageDeleted() ) {
-    //   const deletedMsg = event.args[ 0 ];
-    //   const index = this.rows.findIndex( ( msg ) => msg.id === deletedMsg.id );
-    //
-    //   if ( index !== -1 ) {
-    //     this.rows.splice( index, 1 );
-    //   }
-    // } else if ( event.typeIsLogMessagesCleared() ) {
-    //   this.clearMessages();
-    // }
-  }
-
-  /**
-   * Cleanup code when destroying the editor.
-   */
-  public ngOnDestroy(): void {
-    this.subscription.unsubscribe();
-  }
 
   /**
    * Initialization code run after construction.
    */
   public ngOnInit(): void {
-    this.subscription = this.editorService.editorEvent.subscribe( ( event ) => this.handleEditorEvent( event ) );
-
     this.columns = [
       {
-        prop: "id"
+        name: "ID",
+        prop: Message.ID_PROP_NAME
       },
       {
-        prop: "type"
+        name: "Type",
+        prop: Message.TYPE_PROP_NAME
       },
       {
-        prop: "description"
+        name: "Description",
+        prop: Message.DESCRIPTION_PROP_NAME
       },
       {
-        prop: "context"
+        name: "Context",
+        prop: Message.CONTEXT_PROP_NAME
       },
     ];
 
     this.ngxConfig = {
-      headerHeight: 40,
+      headerHeight: 30,
       rowHeight: 20,
       scrollbarH: true,
       scrollbarV: true

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/editor-views/message-log/message.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/editor-views/message-log/message.ts
@@ -19,6 +19,12 @@ import { Problem } from "@dataservices/virtualization/view-editor/editor-views/m
 
 export class Message {
 
+  // Property names
+  public static readonly CONTEXT_PROP_NAME = "_context";
+  public static readonly DESCRIPTION_PROP_NAME = "_description";
+  public static readonly ID_PROP_NAME = "_id";
+  public static readonly TYPE_PROP_NAME = "_type";
+
   private readonly _context: string;
   private readonly _description: string;
   private readonly _id: string;

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/event/view-editor-event.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/event/view-editor-event.ts
@@ -109,7 +109,22 @@ export class ViewEditorEvent {
    * @returns {string} a string representation of the event
    */
   public toString(): string {
-    return `event type: ${this.type}, source: ${this.source}, arg count: ${this.args.length}`;
+    let text = `event type: ${this.type}, source: ${this.source}, args: `;
+    let firstTime = true;
+
+    if ( this.args && this.args.length !== 0 ) {
+      for ( const arg of this.args ) {
+        if ( firstTime ) {
+          firstTime = false;
+        } else {
+          text += ", ";
+        }
+
+        text += arg;
+      }
+    }
+
+    return text;
   }
 
   /**

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor-header/view-editor-header.component.html
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor-header/view-editor-header.component.html
@@ -26,6 +26,7 @@
              id="view-name-input"
              name="view-name-input"
              placeholder="Enter a view name"
+             autofocus
              [(ngModel)]="viewName"
              [readonly]="readOnly"
              (input)="viewNameChanged($event.target.value)"

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor-header/view-editor-header.component.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor-header/view-editor-header.component.ts
@@ -20,8 +20,8 @@ import { LoggerService } from "@core/logger.service";
 import { ViewEditorPart } from "@dataservices/virtualization/view-editor/view-editor-part.enum";
 import { ViewEditorService } from "@dataservices/virtualization/view-editor/view-editor.service";
 import { ViewEditorEvent } from "@dataservices/virtualization/view-editor/event/view-editor-event";
-import { Subscription } from "rxjs/Subscription";
 import { ViewStateChangeId } from "@dataservices/virtualization/view-editor/event/view-state-change-id.enum";
+import { Subscription } from "rxjs/Subscription";
 
 @Component({
   encapsulation: ViewEncapsulation.None,
@@ -87,10 +87,12 @@ export class ViewEditorHeaderComponent implements OnInit, OnDestroy {
    */
   public set viewDescription( newDescription: string ) {
     if ( this.editorService.getEditorView() ) {
-      this.editorService.getEditorView().setDescription( newDescription );
-      this.editorService.fireViewStateHasChanged( ViewEditorPart.HEADER,
-                                                  ViewStateChangeId.DESCRIPTION,
-                                                  [ newDescription ] );
+      if ( newDescription !== this.editorService.getEditorView().getDescription() ) {
+        this.editorService.getEditorView().setDescription( newDescription );
+        this.editorService.fireViewStateHasChanged( ViewEditorPart.HEADER,
+                                                    ViewStateChangeId.DESCRIPTION,
+                                                    [ newDescription ] );
+      }
     } else {
       // shouldn't get here as description text input should be disabled if no view being edited
       this.logger.error( "Trying to set description but there is no view being edited" );
@@ -122,10 +124,12 @@ export class ViewEditorHeaderComponent implements OnInit, OnDestroy {
    */
   public set viewName( newName: string ) {
     if ( this.editorService.getEditorView() ) {
-      this.editorService.getEditorView().setName( newName );
-      this.editorService.fireViewStateHasChanged( ViewEditorPart.HEADER,
-                                                  ViewStateChangeId.NAME,
-                                                  [ newName ] );
+      if ( newName !== this.editorService.getEditorView().getName() ) {
+        this.editorService.getEditorView().setName( newName );
+        this.editorService.fireViewStateHasChanged( ViewEditorPart.HEADER,
+                                                    ViewStateChangeId.NAME,
+                                                    [ newName ] );
+      }
     } else {
       // shouldn't get here as description text input should be disabled if no view being edited
       this.logger.error( "Trying to set name but there is no view being edited" );

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor.component.css
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor.component.css
@@ -10,7 +10,6 @@
   height: 90vh;
   justify-content: stretch;
   overflow-y: auto;
-  padding: 4px;
   width: 100%;
 }
 
@@ -20,7 +19,7 @@
 .view-editor-area {
   background-color: #ededed;
   border: 1px solid #bbbbbb;
-  padding: 0 20px;
+  padding: 0;
 }
 
 /*

--- a/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor.service.ts
+++ b/src/main/ngapp/src/app/dataservices/virtualization/view-editor/view-editor.service.ts
@@ -87,7 +87,7 @@ export class ViewEditorService {
    */
   public clearMessages( source: ViewEditorPart,
                         context?: string ): void {
-    this._messages.length = 0;
+    this._messages = [];
     this._errorMsgCount = 0;
     this._warningMsgCount = 0;
     this._infoMsgCount = 0;


### PR DESCRIPTION
- message log no longer subscribes to editor events
- now including args in ViewEditorEvent.toString()
- ViewEditorHeaderComponent checks to make sure it only fires a view state has changed event if the name or description actually changed
- removed padding on overall editor and on editor's bottom panel tabs
- message log is actually getting cleared now when needed where before it wasn't